### PR TITLE
post increment operator

### DIFF
--- a/Code/Java/InfiniteLoop.java
+++ b/Code/Java/InfiniteLoop.java
@@ -1,0 +1,9 @@
+package Operators;
+
+public class InfiniteLoop {
+    public static void main(String... input) {
+        for (int i = 0; i < 4; i = i++ ) {
+            System.out.println("Hi");
+        }
+    }
+}


### PR DESCRIPTION
Example of use of post increment operator that creates infinite loop. This operator is meant to be used by itself, if not it might cause the infinite loop like in this example when used together with assignment operator.